### PR TITLE
[#1] Rename Container -> Envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ require_once 'vendor/autoload.php';
 
 $api = new Api(new Client());
 
-// First off, let's create a new container.
-$container = $api->create();
+// First off, let's create a new envelope.
+$envelope = $api->create();
 
 // Add the files you want to get signed.
-$container->addFile('/path/to/file.txt');
-$container->addFile('/second/path/to/file.md');
+$envelope->addFile('/path/to/file.txt');
+$envelope->addFile('/second/path/to/file.md');
 
 // Add a signature or two. Signature takes in certificate id and certificate
 // signature. You must retrieve these from the client using the browser plugin.
-$container->addSignature($signature = new Signature('F1..20', '8F..C0'));
+$envelope->addSignature($signature = new Signature('F1..20', '8F..C0'));
 
 // Sync up with the server. For example, the previous signature is given
 // a challenge, which the client must solve.
-$api->update($container);
+$api->update($envelope);
 
 printf("Challenge: %s\n", $signature->getChallenge());
 
@@ -41,14 +41,14 @@ printf("Challenge: %s\n", $signature->getChallenge());
 $signature->setSolution('F6..00');
 
 // Sync up with the server once more to send the solution.
-$api->update($container);
+$api->update($envelope);
 
 // Time to write it on the disc.
-$api->write('/tmp/my-newly-created-container.bdoc');
+$api->write('/tmp/my-newly-created-envelope.bdoc');
 
-// Make sure to "close" the container (basically closes the session in the
+// Make sure to "close" the envelope (basically closes the session in the
 // remote DigiDoc service).
-$api->close($container);
+$api->close($envelope);
 
 ```
 

--- a/src/ApiInterface.php
+++ b/src/ApiInterface.php
@@ -14,54 +14,54 @@ namespace KG\DigiDoc;
 interface ApiInterface
 {
     /**
-     * Creates a new DigiDoc container.
+     * Creates a new DigiDoc envelope.
      *
      * @api
      *
-     * @return Container
+     * @return Envelope
      */
     public function create();
 
     /**
-     * Creates a new DigiDoc container from its string contents.
+     * Creates a new DigiDoc envelope from its string contents.
      *
      * @api
      *
-     * @param string $bytes  DigiDoc container raw bytes
+     * @param string $bytes  DigiDoc envelope raw bytes
      *
-     * @return Container
+     * @return Envelope
      */
     public function fromString($bytes);
 
     /**
-     * Opens a DigiDoc container given the path to it.
+     * Opens a DigiDoc envelope given the path to it.
      *
      * @todo Perhaps it's possible to create a stream of some sort?
      *
      * @api
      *
-     * @param string $path Path to the DigiDoc container
+     * @param string $path Path to the DigiDoc envelope
      *
-     * @return Container
+     * @return Envelope
      */
     public function open($path);
 
     /**
      * Closes the session between the local and remote systems of the given
-     * DigiDoc container. This must be the last method called after all other
+     * DigiDoc envelope. This must be the last method called after all other
      * transactions.
      *
      * @todo Think of solutions where this would not be necessary
      *
      * @api
      *
-     * @param Container $container
+     * @param Envelope $envelope
      */
-    public function close(Container $container);
+    public function close(Envelope $envelope);
 
     /**
      * Updates the state in the remote api to match the contents of the given
-     * DigiDoc container. The following is done in the same order:
+     * DigiDoc envelope. The following is done in the same order:
      *
      *  - new files uploaded;
      *  - new signatures added and challenges injected;
@@ -69,43 +69,43 @@ interface ApiInterface
      *
      * @api
      *
-     * @param Container $container
+     * @param Envelope $envelope
      */
-    public function update(Container $container);
+    public function update(Envelope $envelope);
 
     /**
-     * Downloads the contents of the DigiDoc container from the server and
+     * Downloads the contents of the DigiDoc envelope from the server and
      * outputs it.
      *
      * @todo Perhaps it's possible to create a stream of some sort?
      *
      * @api
      *
-     * @param Container $container
+     * @param Envelope $envelope
      *
      * @return string
      */
-    public function toString(Container $container);
+    public function toString(Envelope $envelope);
 
     /**
-     * Downloads the contents of the DigiDoc container from the server and
-     * writes them to the given local path. If you modify a container and call
+     * Downloads the contents of the DigiDoc envelope from the server and
+     * writes them to the given local path. If you modify a envelope and call
      * this method without prior updating, the changes will not be reflected
      * in the written file.
      *
      * @api
      *
-     * @param Container $container
-     * @param string    $path
+     * @param Envelope $envelope
+     * @param string   $path
      */
-    public function write(Container $container, $path);
+    public function write(Envelope $envelope, $path);
 
     /**
-     * Merges the DigiDoc container back with the api. This is necessary, when
-     * working with a container over multiple requests and storing it somewhere
+     * Merges the DigiDoc envelope back with the api. This is necessary, when
+     * working with a envelope over multiple requests and storing it somewhere
      * (session, database etc) inbetween the requests.
      *
-     * @param Container $container
+     * @param Envelope $envelope
      */
-    public function merge(Container $container);
+    public function merge(Envelope $envelope);
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -11,103 +11,10 @@
 
 namespace KG\DigiDoc;
 
-use KG\DigiDoc\Exception\UnexpectedTypeException;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
-
-class Container
+/**
+ * @deprecated Deprecated since version 0.1.2, to be removed in 1.0.0
+ */
+class Container extends Envelope
 {
-    /**
-     * @var \Doctrine\Common\Collections\Collection
-     */
-    private $files;
 
-    /**
-     * @var \Doctrine\Common\Collections\Collection
-     */
-    private $signatures;
-
-    /**
-     * @var Session
-     */
-    private $session;
-
-    /**
-     * @param Session     $session
-     * @param File[]      $files
-     * @param Signature[] $signatures
-     */
-    public function __construct(Session $session, $files = array(), $signatures = array())
-    {
-        $this->session = $session;
-        $this->files = $files instanceof Collection ? $files : new ArrayCollection($files);
-        $this->signatures = $signatures instanceof Collection ? $signatures : new ArrayCollection($signatures);
-    }
-
-    /**
-     * @return Session
-     */
-    public function getSession()
-    {
-        return $this->session;
-    }
-
-    /**
-     * Adds a new file to the container. NB! Files cannot be added once the
-     * container has at least 1 signature.
-     *
-     * @param string|File $pathOrFile
-     */
-    public function addFile($pathOrFile)
-    {
-        $file = is_string($pathOrFile) ? new File($pathOrFile) : $pathOrFile;
-
-        if (!($file instanceof File)) {
-            throw new UnexpectedTypeException('string" or "\KG\DigiDoc\File', $file);
-        }
-
-        $this->getFiles()->add($file);
-    }
-
-    /**
-     * @return Collection
-     */
-    public function getFiles()
-    {
-        return $this->files;
-    }
-
-    /**
-     * Adds a new signature to the archive.
-     *
-     * @param Signature $signature
-     */
-    public function addSignature(Signature $signature)
-    {
-        $this->getSignatures()->add($signature);
-    }
-
-    /**
-     * @return Collection
-     */
-    public function getSignatures()
-    {
-        return $this->signatures;
-    }
-
-    /**
-     * Gets a signature given it's id in the container.
-     *
-     * @param string $signatureId The signature id (e.g. "S01")
-     *
-     * @return Signature|null The found signature or null, if no match was found
-     */
-    public function getSignature($signatureId)
-    {
-        foreach ($this->getSignatures() as $signature) {
-            if ($signature->getId() === $signatureId) {
-                return $signature;
-            }
-        }
-    }
 }

--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc;
+
+use KG\DigiDoc\Exception\UnexpectedTypeException;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+class Envelope
+{
+    /**
+     * @var \Doctrine\Common\Collections\Collection
+     */
+    private $files;
+
+    /**
+     * @var \Doctrine\Common\Collections\Collection
+     */
+    private $signatures;
+
+    /**
+     * @var Session
+     */
+    private $session;
+
+    /**
+     * @param Session     $session
+     * @param File[]      $files
+     * @param Signature[] $signatures
+     */
+    public function __construct(Session $session, $files = array(), $signatures = array())
+    {
+        $this->session = $session;
+        $this->files = $files instanceof Collection ? $files : new ArrayCollection($files);
+        $this->signatures = $signatures instanceof Collection ? $signatures : new ArrayCollection($signatures);
+    }
+
+    /**
+     * @return Session
+     */
+    public function getSession()
+    {
+        return $this->session;
+    }
+
+    /**
+     * Adds a new file to the envelope. NB! Files cannot be added once the
+     * envelope has at least 1 signature.
+     *
+     * @param string|File $pathOrFile
+     */
+    public function addFile($pathOrFile)
+    {
+        $file = is_string($pathOrFile) ? new File($pathOrFile) : $pathOrFile;
+
+        if (!($file instanceof File)) {
+            throw new UnexpectedTypeException('string" or "\KG\DigiDoc\File', $file);
+        }
+
+        $this->getFiles()->add($file);
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getFiles()
+    {
+        return $this->files;
+    }
+
+    /**
+     * Adds a new signature to the archive.
+     *
+     * @param Signature $signature
+     */
+    public function addSignature(Signature $signature)
+    {
+        $this->getSignatures()->add($signature);
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getSignatures()
+    {
+        return $this->signatures;
+    }
+
+    /**
+     * Gets a signature given it's id in the envelope.
+     *
+     * @param string $signatureId The signature id (e.g. "S01")
+     *
+     * @return Signature|null The found signature or null, if no match was found
+     */
+    public function getSignature($signatureId)
+    {
+        foreach ($this->getSignatures() as $signature) {
+            if ($signature->getId() === $signatureId) {
+                return $signature;
+            }
+        }
+    }
+}

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -11,7 +11,7 @@
 
 namespace KG\DigiDoc\Exception;
 
-use KG\DigiDoc\Container;
+use KG\DigiDoc\Envelope;
 
 /**
  * ApiException is a generic exception for failed api calls.
@@ -95,16 +95,16 @@ class ApiException extends DigiDocException
     }
 
     /**
-     * Creates a new ApiException for non-merged DigiDoc containers.
+     * Creates a new ApiException for non-merged DigiDoc envelopes.
      *
-     * @param Container       $container
+     * @param Envelope        $envelope
      * @param \Exception|null $e
      *
      * @return ApiException
      */
-    public static function createNotMerged(Container $contaienr, \Exception $e = null)
+    public static function createNotMerged(Envelope $envelope, \Exception $e = null)
     {
-        $message = 'The given DigiDoc container must be merged with Api (using Api::merge) before calling this method.';
+        $message = 'The given DigiDoc envelope must be merged with Api (using Api::merge) before calling this method.';
 
         return new static($message, null, $e);
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -12,11 +12,11 @@
 namespace KG\DigiDoc\Tests\ApiTest;
 
 use KG\DigiDoc\Api;
-use KG\DigiDoc\Container;
+use KG\DigiDoc\Envelope;
 
 class ApiTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCreateCreatesNewContainer()
+    public function testCreateCreatesNewEnvelope()
     {
         $client = $this->getMockClient();
         $this->mockStartSession($client, $sessionId = 42);
@@ -29,13 +29,13 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api($client, $this->getMockEncoder(), $this->getMockTracker());
 
-        $container = $api->create();
+        $envelope = $api->create();
 
-        $this->assertInstanceOf('KG\DigiDoc\Container', $container);
-        $this->assertEquals($sessionId, $container->getSession()->getId());
+        $this->assertInstanceOf('KG\DigiDoc\Envelope', $envelope);
+        $this->assertEquals($sessionId, $envelope->getSession()->getId());
     }
 
-    public function testOpenCreatesNewContainer()
+    public function testOpenCreatesNewEnvelope()
     {
         $info = $this->getMockSignedDocInfo();
         $info->DataFileInfo = $info->SignatureInfo = null;
@@ -55,13 +55,13 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api($client, $this->getMockEncoder(), $this->getMockTracker());
 
-        $container = $api->open('/path/to/file.bdoc');
+        $envelope = $api->open('/path/to/file.bdoc');
 
-        $this->assertInstanceOf('KG\DigiDoc\Container', $container);
-        $this->assertEquals($sessionId, $container->getSession()->getId());
+        $this->assertInstanceOf('KG\DigiDoc\Envelope', $envelope);
+        $this->assertEquals($sessionId, $envelope->getSession()->getId());
     }
 
-    public function testOpenAddsFilesToContainer()
+    public function testOpenAddsFilesToEnvelope()
     {
         $fileInfo = $this->getMockDataFileInfo();
         $fileInfo->Id = 'example.doc';
@@ -85,13 +85,13 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api($client, $this->getMockEncoder(), $this->getMockTracker());
 
-        $container = $api->open('/path/to/file.bdoc');
-        $file = $container->getFiles()->first();
+        $envelope = $api->open('/path/to/file.bdoc');
+        $file = $envelope->getFiles()->first();
 
         $this->assertSame($fileInfo->Id, $file->getId());
     }
 
-    public function testOpenAddsSignaturesToContainer()
+    public function testOpenAddsSignaturesToEnvelope()
     {
         $signatureInfo = $this->getMockSignatureInfo();
         $signatureInfo->Id = 'S0';
@@ -115,8 +115,8 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api($client, $this->getMockEncoder(), $this->getMockTracker());
 
-        $container = $api->open('/path/to/file.bdoc');
-        $signature = $container->getSignatures()->first();
+        $envelope = $api->open('/path/to/file.bdoc');
+        $signature = $envelope->getSignatures()->first();
 
         $this->assertSame($signatureInfo->Id, $signature->getId());
     }
@@ -131,9 +131,9 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($sessionId = 69))
         ;
 
-        $container = $this->getMockContainer();
+        $envelope = $this->getMockEnvelope();
 
-        $container
+        $envelope
             ->expects($this->once())
             ->method('getSession')
             ->will($this->returnValue($session))
@@ -148,41 +148,41 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         ;
 
         $api = new Api($client, $this->getMockEncoder(), $this->getMockTracker());
-        $api->close($container);
+        $api->close($envelope);
     }
 
     /**
      * @expectedException \KG\DigiDoc\Exception\ApiException
-     * @expectedExceptionMessage DigiDoc container must be merged with Api
+     * @expectedExceptionMessage DigiDoc envelope must be merged with Api
      */
-    public function testUpdateFailsIfContainerNotMerged()
+    public function testUpdateFailsIfEnvelopeNotMerged()
     {
         $api = new Api($this->getMockClient());
-        $api->update($this->getMockContainer());
+        $api->update($this->getMockEnvelope());
     }
 
-    public function testUpdateAddsContainerToTrackerIfMergeTrue()
+    public function testUpdateAddsEnvelopeToTrackerIfMergeTrue()
     {
-        $container = new Container($this->getMockSession());
+        $envelope = new Envelope($this->getMockSession());
 
         $tracker = $this->getMockTracker();
         $tracker
             ->expects($this->at(1))
             ->method('add')
-            ->with($container)
+            ->with($envelope)
         ;
 
         $api = new Api($this->getMockClient(), null, $tracker);
-        $api->update($container, true);
+        $api->update($envelope, true);
     }
 
     /**
-     * @return \KG\DigiDoc\Container|PHPUnit_Framework_MockObject_MockObject
+     * @return \KG\DigiDoc\Envelope|PHPUnit_Framework_MockObject_MockObject
      */
-    private function getMockContainer()
+    private function getMockEnvelope()
     {
         return $this
-            ->getMockBuilder('KG\DigiDoc\Container')
+            ->getMockBuilder('KG\DigiDoc\Envelope')
             ->disableOriginalConstructor()
             ->getMock()
         ;

--- a/tests/EnvelopeTest.php
+++ b/tests/EnvelopeTest.php
@@ -9,20 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace KG\DigiDoc\Tests;
+namespace KG\DigiDoc\tests;
 
-use KG\DigiDoc\Container;
+use KG\DigiDoc\Envelope;
 
-/**
- * @deprecated Deprecated since version 0.1.2, to be removed in 1.0.0
- */
-class ContainerTest extends \PHPUnit_Framework_TestCase
+class EnvelopeTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetSignatureReturnsNullIfNoSuchId()
     {
-        $container = new Container($this->getMockSession());
+        $envelope = new Envelope($this->getMockSession());
 
-        $this->assertNull($container->getSignature('S01'));
+        $this->assertNull($envelope->getSignature('S01'));
     }
 
     public function testGetSignatureReturnsSignatureById()
@@ -34,10 +31,10 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($signatureId = 'S01'))
         ;
 
-        $container = new Container($this->getMockSession());
-        $container->addSignature($signature);
+        $envelope = new Envelope($this->getMockSession());
+        $envelope->addSignature($signature);
 
-        $this->assertSame($signature, $container->getSignature($signatureId));
+        $this->assertSame($signature, $envelope->getSignature($signatureId));
     }
 
     /**


### PR DESCRIPTION
I find `Envelope` to be a more suitable name in place of `Container`. Essentially it's an "envelope" of files and signature.
