### PR TITLE
[#2] OCSP request & response parsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/http-foundation": "~2.0",
         "ext-zip": "*",
         "doctrine/collections": "~1.0",
-        "symfony/process": "~2.0"
+        "symfony/process": "~2.0",
+        "phpseclib/phpseclib": "dev-php5"
     },
     "require-dev": {
         "wsdl2phpgenerator/wsdl2phpgenerator": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "doctrine/collections": "~1.0"
     },
     "require-dev": {
-        "wsdl2phpgenerator/wsdl2phpgenerator": "~2.3"
+        "wsdl2phpgenerator/wsdl2phpgenerator": "~2.3",
+        "mikey179/vfsStream": "~1.4"
     },
     "autoload": {
         "psr-4": { "KG\\DigiDoc\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "ext-soap": "*",
         "symfony/http-foundation": "~2.0",
         "ext-zip": "*",
-        "doctrine/collections": "~1.0"
+        "doctrine/collections": "~1.0",
+        "symfony/process": "~2.0"
     },
     "require-dev": {
         "wsdl2phpgenerator/wsdl2phpgenerator": "~2.3",

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace KG\DigiDoc\Exception;
+
+/**
+ * @todo Have a custom exception message.
+ */
+class FileNotFoundException extends RuntimeException
+{
+
+}

--- a/src/Exception/OcspRequestException.php
+++ b/src/Exception/OcspRequestException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc\Exception;
+
+class OcspRequestException extends RuntimeException
+{
+
+}

--- a/src/Ocsp/Asn1.php
+++ b/src/Ocsp/Asn1.php
@@ -32,121 +32,79 @@ class Asn1
     const OID_OCSP_NONCE = '1.3.6.1.5.5.7.48.1.2';
 
     /**
-     * BasicOCSPResponse ::= SEQUENCE {
-     *     tbsResponseData         ResponseData,
-     *     signatureAlgorithm      AlgorithmIdentifier,
-     *     signature               BIT STRING,
-     *     certs               [0] EXPLICIT SEQUENCE OF Certificate OPTIONAL
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
+     *
+     * @var array
      */
     public $BasicOCSPResponse;
 
     /**
-     * CertID ::= SEQUENCE {
-     *     hashAlgorithm       AlgorithmIdentifier {DIGEST-ALGORITHM, {...}},
-     *     issuerNameHash      OCTET STRING, -- Hash of issuer's DN
-     *     issuerKeyHash       OCTET STRING, -- Hash of issuer's public key
-     *     serialNumber        CertificateSerialNumber
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.1.1
      *
      * @var array
      */
     public $CertID;
 
     /**
-     * CertStatus ::= CHOICE {
-     *     good                [0] IMPLICIT NULL,
-     *     revoked             [1] IMPLICIT RevokedInfo,
-     *     unknown             [2] IMPLICIT UnknownInfo
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
      *
      * @var array
      */
     public $CertStatus;
 
     /**
-     * OCSPResponse ::= SEQUENCE {
-     *     responseStatus          OCSPResponseStatus,
-     *     responseBytes       [0] EXPLICIT ResponseBytes OPTIONAL
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
      *
      * @var array
      */
     public $OCSPResponse;
 
     /**
-     * OCSPResponseStatus ::= ENUMERATED {
-     *     successful          (0),  -- Response has valid confirmations
-     *     malformedRequest    (1),  -- Illegal confirmation request
-     *     internalError       (2),  -- Internal error in issuer
-     *     tryLater            (3),  -- Try again later
-     *                               -- (4) is not used
-     *     sigRequired         (5),  -- Must sign the request
-     *     unauthorized        (6)   -- Request unauthorized
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
      *
      * @var array
      */
     public $OCSPResponseStatus;
 
     /**
-     * ResponderID ::= CHOICE {
-     *     byName              [1] Name,
-     *     byKey               [2] KeyHash
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.2.3
      *
      * @var array
      */
     public $ResponderID;
 
     /**
-     * ResponseBytes ::= SEQUENCE {
-     *     responseType            OBJECT IDENTIFIER,
-     *     response                OCTET STRING
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
      *
      * @var array
      */
     public $ResponseBytes;
 
     /**
-     * ResponseData ::= SEQUENCE {
-     *     version             [0] EXPLICIT Version DEFAULT v1,
-     *     responderID             ResponderID,
-     *     producedAt              GeneralizedTime,
-     *     responses               SEQUENCE OF SingleResponse,
-     *     responseExtensions  [1] EXPLICIT Extensions OPTIONAL
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
      *
      * @var array
      */
     public $ResponseData;
 
     /**
-     * RevokedInfo ::= SEQUENCE {
-     *     revocationTime          GeneralizedTime,
-     *     revocationReason    [0] EXPLICIT CRLReason OPTIONAL
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
      *
      * @var array
      */
     public $RevokedInfo;
 
     /**
-     * SingleResponse ::= SEQUENCE {
-     *     certID                  CertID,
-     *     certStatus              CertStatus,
-     *     thisUpdate              GeneralizedTime,
-     *     nextUpdate          [0] EXPLICIT GeneralizedTime OPTIONAL,
-     *     singleExtensions    [1] EXPLICIT Extensions{{re-ocsp-crl | re-ocsp-archive-cutoff | CrlEntryExtensions, ...}} OPTIONAL
-     * }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.2.3
      *
      * @var array
      */
     public $SingleResponse;
 
     /**
-     * Version ::= INTEGER { v1(0) }
+     * @see https://tools.ietf.org/html/rfc6960#section-4.1.1
      *
      * @var array
      */

--- a/src/Ocsp/Asn1.php
+++ b/src/Ocsp/Asn1.php
@@ -33,6 +33,11 @@ class Asn1
 
     /**
      * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
+     */
+    const OID_ID_PKIX_OCSP_BASIC = '1.3.6.1.5.5.7.48.1.1';
+
+    /**
+     * @see https://tools.ietf.org/html/rfc6960#section-4.2.1
      *
      * @var array
      */

--- a/src/Ocsp/Asn1.php
+++ b/src/Ocsp/Asn1.php
@@ -1,0 +1,322 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc\Ocsp;
+
+use KG\DigiDoc\X509\Asn1 as X509Asn1;
+use phpseclib\File\ASN1 as BaseAsn1;
+
+/**
+ * A subset of OCSP ASN.1 used by this library. Casing of properties matches
+ * the spec
+ *
+ * @see https://tools.ietf.org/html/rfc6960#appendix-B.1
+ */
+class Asn1
+{
+    const OCSP_SUCCESSFUL = 0;
+    const OCSP_MALFORMED_REQUEST = 1;
+    const OCSP_INTERNAL_ERROR = 2;
+    const OCSP_TRY_LATER = 3;
+    const OCSP_SIG_REQUIRED = 5;
+    const OCSP_UNAUTHORIZED = 6;
+
+    const OID_OCSP_NONCE = '1.3.6.1.5.5.7.48.1.2';
+
+    /**
+     * BasicOCSPResponse ::= SEQUENCE {
+     *     tbsResponseData         ResponseData,
+     *     signatureAlgorithm      AlgorithmIdentifier,
+     *     signature               BIT STRING,
+     *     certs               [0] EXPLICIT SEQUENCE OF Certificate OPTIONAL
+     * }
+     */
+    public $BasicOCSPResponse;
+
+    /**
+     * CertID ::= SEQUENCE {
+     *     hashAlgorithm       AlgorithmIdentifier {DIGEST-ALGORITHM, {...}},
+     *     issuerNameHash      OCTET STRING, -- Hash of issuer's DN
+     *     issuerKeyHash       OCTET STRING, -- Hash of issuer's public key
+     *     serialNumber        CertificateSerialNumber
+     * }
+     *
+     * @var array
+     */
+    public $CertID;
+
+    /**
+     * CertStatus ::= CHOICE {
+     *     good                [0] IMPLICIT NULL,
+     *     revoked             [1] IMPLICIT RevokedInfo,
+     *     unknown             [2] IMPLICIT UnknownInfo
+     * }
+     *
+     * @var array
+     */
+    public $CertStatus;
+
+    /**
+     * OCSPResponse ::= SEQUENCE {
+     *     responseStatus          OCSPResponseStatus,
+     *     responseBytes       [0] EXPLICIT ResponseBytes OPTIONAL
+     * }
+     *
+     * @var array
+     */
+    public $OCSPResponse;
+
+    /**
+     * OCSPResponseStatus ::= ENUMERATED {
+     *     successful          (0),  -- Response has valid confirmations
+     *     malformedRequest    (1),  -- Illegal confirmation request
+     *     internalError       (2),  -- Internal error in issuer
+     *     tryLater            (3),  -- Try again later
+     *                               -- (4) is not used
+     *     sigRequired         (5),  -- Must sign the request
+     *     unauthorized        (6)   -- Request unauthorized
+     * }
+     *
+     * @var array
+     */
+    public $OCSPResponseStatus;
+
+    /**
+     * ResponderID ::= CHOICE {
+     *     byName              [1] Name,
+     *     byKey               [2] KeyHash
+     * }
+     *
+     * @var array
+     */
+    public $ResponderID;
+
+    /**
+     * ResponseBytes ::= SEQUENCE {
+     *     responseType            OBJECT IDENTIFIER,
+     *     response                OCTET STRING
+     * }
+     *
+     * @var array
+     */
+    public $ResponseBytes;
+
+    /**
+     * ResponseData ::= SEQUENCE {
+     *     version             [0] EXPLICIT Version DEFAULT v1,
+     *     responderID             ResponderID,
+     *     producedAt              GeneralizedTime,
+     *     responses               SEQUENCE OF SingleResponse,
+     *     responseExtensions  [1] EXPLICIT Extensions OPTIONAL
+     * }
+     *
+     * @var array
+     */
+    public $ResponseData;
+
+    /**
+     * RevokedInfo ::= SEQUENCE {
+     *     revocationTime          GeneralizedTime,
+     *     revocationReason    [0] EXPLICIT CRLReason OPTIONAL
+     * }
+     *
+     * @var array
+     */
+    public $RevokedInfo;
+
+    /**
+     * SingleResponse ::= SEQUENCE {
+     *     certID                  CertID,
+     *     certStatus              CertStatus,
+     *     thisUpdate              GeneralizedTime,
+     *     nextUpdate          [0] EXPLICIT GeneralizedTime OPTIONAL,
+     *     singleExtensions    [1] EXPLICIT Extensions{{re-ocsp-crl | re-ocsp-archive-cutoff | CrlEntryExtensions, ...}} OPTIONAL
+     * }
+     *
+     * @var array
+     */
+    public $SingleResponse;
+
+    /**
+     * Version ::= INTEGER { v1(0) }
+     *
+     * @var array
+     */
+    public $Version;
+
+    /**
+     * @param X509Asn1|null $x509Asn1
+     */
+    public function __construct(X509Asn1 $x509Asn1 = null)
+    {
+        $x509Asn1 = $x509Asn1 ?: new X509Asn1();
+
+        $this->OCSPResponseStatus = array(
+            'type' => BaseAsn1::TYPE_ENUMERATED,
+            'mapping' => array(
+                self::OCSP_SUCCESSFUL => self::OCSP_SUCCESSFUL,
+                self::OCSP_MALFORMED_REQUEST => self::OCSP_MALFORMED_REQUEST,
+                self::OCSP_INTERNAL_ERROR => self::OCSP_INTERNAL_ERROR,
+                self::OCSP_TRY_LATER => self::OCSP_TRY_LATER,
+                self::OCSP_SIG_REQUIRED => self::OCSP_SIG_REQUIRED,
+                self::OCSP_UNAUTHORIZED => self::OCSP_UNAUTHORIZED,
+            )
+        );
+
+        $this->ResponseBytes = array(
+            'constant' => 0,
+            'optional' => true,
+            'explicit' => true,
+            'type' => BaseAsn1::TYPE_SEQUENCE,
+            'children' => array(
+                'responseType' => array('type' => BaseAsn1::TYPE_OBJECT_IDENTIFIER),
+                // The value for responseBytes consists of an OBJECT IDENTIFIER and a
+                // response syntax identified by that OID encoded as an OCTET STRING.
+                'response' => array('type' => BaseAsn1::TYPE_OCTET_STRING),
+            )
+        );
+
+        $this->OCSPResponse = array(
+            'type' => BaseAsn1::TYPE_SEQUENCE,
+            'children' => array(
+                'responseStatus' => $this->OCSPResponseStatus,
+                'responseBytes' => $this->ResponseBytes
+            ),
+        );
+
+        $this->RevokedInfo = array(
+            'type' => BaseAsn1::TYPE_SEQUENCE,
+            'children' => array(
+                'revocationTime' => array('type' => BaseAsn1::TYPE_GENERALIZED_TIME),
+                'revocationReason' => $x509Asn1->CRLReason + array(
+                    'constant' => 0,
+                    'explicit' => true,
+                    'optional' => true,
+                ),
+            ),
+        );
+
+        $this->CertStatus = array(
+            'type' => BaseAsn1::TYPE_CHOICE,
+            'children' => array(
+                'good' => array(
+                    'type' => BaseAsn1::TYPE_NULL,
+                    'constant' => 0,
+                    'implicit' => true,
+                ),
+                'revoked' => $this->RevokedInfo + array(
+                    'constant' => 1,
+                    'implicit' => true
+                ),
+                'unknown' => array(
+                    'constant' => 2,
+                    'implicit' => true,
+                    'type' => BaseAsn1::TYPE_NULL,
+                ),
+            ),
+        );
+
+        $this->Version = array(
+            'type' => BaseAsn1::TYPE_INTEGER,
+            'mapping' => array(0 => 'v1'),
+        );
+
+        $this->ResponderID = array(
+            'type' => BaseAsn1::TYPE_CHOICE,
+            'children' => array(
+                // Added 'explicit' => true - otherwise the parser breaks.
+                'byName' => $x509Asn1->Name + array('constant' => 1, 'explicit' => true),
+                'byKey' => array(
+                    'constant' => 2,
+                    // SHA-1 hash of responder's public key
+                    'type' => BaseAsn1::TYPE_OCTET_STRING,
+                ),
+            ),
+        );
+
+        $this->CertID = array(
+            'type' => BaseAsn1::TYPE_SEQUENCE,
+            'children' => array(
+                'hashAlgorithm' => $x509Asn1->AlgorithmIdentifier,
+                'issuerNameHash' => array('type' => BaseAsn1::TYPE_OCTET_STRING),
+                'issuerKeyHash' => array('type' => BaseAsn1::TYPE_OCTET_STRING),
+                'serialNumber' => $x509Asn1->CertificateSerialNumber,
+            ),
+        );
+
+        $this->SingleResponse = array(
+            'type' => BaseAsn1::TYPE_SEQUENCE,
+            'children' => array(
+                'certID' => $this->CertID,
+                'certStatus' => $this->CertStatus,
+                'thisUpdate' => array(
+                    'type' => BaseAsn1::TYPE_GENERALIZED_TIME,
+                ),
+                'nextUpdate' => array(
+                    'type' => BaseAsn1::TYPE_GENERALIZED_TIME,
+                    'constant' => 0,
+                    'explicit' => true,
+                    'optional' => true,
+                ),
+                'singleExtensions' => $x509Asn1->Extensions + array(
+                    'constant' => 1,
+                    'explicit' => true,
+                    'optional' => true,
+                ),
+            ),
+        );
+
+        $this->ResponseData = array(
+            'type' => BaseAsn1::TYPE_SEQUENCE,
+            'children' => array(
+                'version' => $this->Version + array(
+                    'explicit' => true,
+                    'constant' => 0,
+                    'default' => 'v1'
+                ),
+                'responderID' => $this->ResponderID,
+                'producedAt' => array(
+                    'type' => BaseAsn1::TYPE_GENERALIZED_TIME
+                ),
+                'responses' => array(
+                    'type' => BaseAsn1::TYPE_SEQUENCE,
+                    'min' => 0,
+                    'max' => -1,
+                    'children' => $this->SingleResponse
+                ),
+                'responseExtensions' => $x509Asn1->Extensions + array(
+                    'explicit' => true,
+                    'constant' => 1,
+                    'optional' => true,
+                ),
+            ),
+        );
+
+        $this->BasicOCSPResponse = array(
+            'type' => BaseAsn1::TYPE_SEQUENCE,
+            'children' => array(
+                'tbsResponseData' => $this->ResponseData,
+                'signatureAlgorithm' => $x509Asn1->AlgorithmIdentifier,
+                'signature' => array(
+                    'type' => BaseAsn1::TYPE_BIT_STRING
+                ),
+                'certs' => array(
+                    'constant' => 0,
+                    'explicit' => true,
+                    'optional' => true,
+                    'min' => 0,
+                    'max' => -1,
+                    'children' => $x509Asn1->Certificate,
+                ),
+            ),
+        );
+    }
+}

--- a/src/Ocsp/Request.php
+++ b/src/Ocsp/Request.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc\Ocsp;
+
+use KG\DigiDoc\Exception\FileNotFoundException;
+
+/**
+ * Models a single OCSP request.
+ */
+class Request
+{
+    /**
+     * @var string
+     */
+    private $pathToClientCert;
+
+    /**
+     * @var string
+     */
+    private $pathToIssuerCert;
+
+    /**
+     * @param string $pathToClientCert
+     * @param string $pathToIssuerCert
+     *
+     * @throws FileNotFoundException If either of the paths are not files
+     */
+    public function __construct($pathToClientCert, $pathToIssuerCert)
+    {
+        if (!is_file($pathToClientCert)) {
+            throw new FileNotFoundException($pathToClientCert);
+        }
+
+        if (!is_file($pathToIssuerCert)) {
+            throw new FileNotFoundException($pathToIssuerCert);
+        }
+
+        $this->pathToClientCert = $pathToClientCert;
+        $this->pathToIssuerCert = $pathToIssuerCert;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPathToClientCert()
+    {
+        return $this->pathToClientCert;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPathToIssuerCert()
+    {
+        return $this->pathToIssuerCert;
+    }
+}

--- a/src/Ocsp/Responder.php
+++ b/src/Ocsp/Responder.php
@@ -66,6 +66,17 @@ class Responder
      */
     public function handle(Request $request)
     {
+        // @todo what about response verification?
+        return $this->makeRequest($request);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    private function makeRequest(Request $request)
+    {
         $pathToResponse = tempnam($this->tempDir, 'php-digidoc');
 
         $process = $this->createProcess($request, $pathToResponse);

--- a/src/Ocsp/Responder.php
+++ b/src/Ocsp/Responder.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc\Ocsp;
+
+use KG\DigiDoc\Exception\FileNotFoundException;
+use KG\DigiDoc\Exception\OcspRequestException;
+use Symfony\Component\Process\Process;
+
+/**
+ * A wrapper to make OCSP requests using openssl as an external program since
+ * the OpenSSL PHP module doesn't cover OCSP requests.
+ */
+class Responder
+{
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var string
+     */
+    private $pathToCert;
+
+    /**
+     * @var Process
+     */
+    private $process;
+
+    /**
+     * @var string
+     */
+    private $tempDir;
+
+    /**
+     * @param string       $url
+     * @param string       $pathToCert
+     * @param null|string  $tempDir    Path to a directory where temporary files can be written (system temp by default)
+     * @param null|Process $process    The Process object to use (i.e. for testing)
+     */
+    public function __construct($url, $pathToCert, $tempDir = null, Process $process = null)
+    {
+        if (!is_file($pathToCert)) {
+            throw new FileNotFoundException();
+        }
+
+        $this->url = $url;
+        $this->pathToCert = $pathToCert;
+        $this->tempDir = $tempDir ?: sys_get_temp_dir();
+        $this->process = $process ?: new Process('');
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function handle(Request $request)
+    {
+        $pathToResponse = tempnam($this->tempDir, 'php-digidoc');
+
+        $commandLine = sprintf(
+            'openssl ocsp -issuer %s -cert %s -url %s -VAfile %s -respout %s',
+            escapeshellarg($request->getPathToIssuerCert()),
+            escapeshellarg($request->getPathToClientCert()),
+            escapeshellarg($this->url),
+            escapeshellarg($this->pathToCert),
+            escapeshellarg($pathToResponse)
+        );
+
+        $process = $this->process;
+        $process->setCommandLine($commandLine);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new OcspRequestException('OCSP Verification failed: ' . $process->getErrorOutput());
+        }
+
+        return new Response(file_get_contents($pathToResponse));
+    }
+}

--- a/src/Ocsp/Response.php
+++ b/src/Ocsp/Response.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc\Ocsp;
+
+/**
+ * Models an OCSP response.
+ */
+class Response
+{
+    /**
+     * @var string
+     */
+    private $content;
+
+    /**
+     * @param string $content
+     */
+    public function __construct($content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getContent();
+    }
+}

--- a/src/Ocsp/Response.php
+++ b/src/Ocsp/Response.php
@@ -11,11 +11,23 @@
 
 namespace KG\DigiDoc\Ocsp;
 
+use phpseclib\File\ASN1;
+use phpseclib\File\X509;
+
 /**
  * Models an OCSP response.
  */
 class Response
 {
+    const OCSP_SUCCESSFUL = 0;
+    const OCSP_MALFORMED_REQUEST = 1;
+    const OCSP_INTERNAL_ERROR = 2;
+    const OCSP_TRY_LATER = 3;
+    const OCSP_SIG_REQUIRED = 5;
+    const OCSP_UNAUTHORIZED = 6;
+
+    const OID_OCSP_NONCE = '1.3.6.1.5.5.7.48.1.2';
+
     /**
      * @var string
      */
@@ -27,6 +39,31 @@ class Response
     public function __construct($content)
     {
         $this->content = $content;
+    }
+
+    /**
+     * Gets the response status.
+     *
+     * @return integer One of the self::OCSP_* constants
+     */
+    public function getStatus()
+    {
+        $asn1 = new ASN1();
+
+        $responseDecoded = $asn1->decodeBER($this->getContent());
+        $responseMapped = $asn1->asn1map($responseDecoded[0], $this->createOcspResponseAsn1Mapping());
+
+        return $responseMapped['responseStatus'];
+    }
+
+    /**
+     * @param string $nonce Nonce as a binary string to compare against
+     *
+     * @return boolean
+     */
+    public function isNonceEqualTo($nonce)
+    {
+        return $nonce === $this->getNonce();
     }
 
     /**
@@ -43,5 +80,236 @@ class Response
     public function __toString()
     {
         return $this->getContent();
+    }
+
+    /**
+     * @return string Binary string of the nonce
+     */
+    private function getNonce()
+    {
+        $asn1 = new ASN1();
+
+        $responseDecoded = $asn1->decodeBER($this->getContent());
+        $responseMapped = $asn1->asn1map($responseDecoded[0], $this->createOcspResponseAsn1Mapping());
+
+        $asn1 = new ASN1();
+        // @todo make sure to check for response type too!
+        $responseBasicDecoded = $asn1->decodeBER(base64_decode($responseMapped['responseBytes']['response']));
+        $responseBasicMapped = $asn1->asn1map($responseBasicDecoded[0], $this->createBasicOcspResponseAsn1Mapping());
+
+        foreach ($responseBasicMapped['tbsResponseData']['responseExtensions'] as $extension) {
+            if (self::OID_OCSP_NONCE === $extension['extnId']) {
+                return base64_decode($extension['extnValue']);
+            }
+        }
+
+        throw new \RuntimeExcetpion('The response does not contain a nonce.');
+    }
+
+
+    /**
+     * A minimal ASN1 mapping for an OCSP response as specified in
+     * {@link https://tools.ietf.org/html/rfc2560#page-8 [RFC2560]}.
+     *
+     * @return array
+     */
+    private function createOcspResponseAsn1Mapping()
+    {
+        $ocspResponseStatus = array(
+            'type' => ASN1::TYPE_ENUMERATED,
+            'mapping' => array(
+                self::OCSP_SUCCESSFUL => self::OCSP_SUCCESSFUL,
+                self::OCSP_MALFORMED_REQUEST => self::OCSP_MALFORMED_REQUEST,
+                self::OCSP_INTERNAL_ERROR => self::OCSP_INTERNAL_ERROR,
+                self::OCSP_TRY_LATER => self::OCSP_TRY_LATER,
+                self::OCSP_SIG_REQUIRED => self::OCSP_SIG_REQUIRED,
+                self::OCSP_UNAUTHORIZED => self::OCSP_UNAUTHORIZED,
+            )
+        );
+
+        $responseBytes = array(
+            'constant' => 0,
+            'optional' => true,
+            'explicit' => true,
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => array(
+                'responseType' => array('type' => ASN1::TYPE_OBJECT_IDENTIFIER),
+                // The value for responseBytes consists of an OBJECT IDENTIFIER and a
+                // response syntax identified by that OID encoded as an OCTET STRING.
+                'response' => array('type' => ASN1::TYPE_OCTET_STRING),
+            )
+        );
+
+        $ocspResponse = array(
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => array(
+                'responseStatus' => $ocspResponseStatus,
+                'responseBytes' => $responseBytes
+            ),
+        );
+
+        return $ocspResponse;
+    }
+
+    /**
+     * ASN1 mapping for responses of the id-pkix-ocsp-basic response type as
+     * specified in {@link https://tools.ietf.org/html/rfc2560#page-9 [RFC2560]}.
+     *
+     * @return array
+     */
+    private function createBasicOcspResponseAsn1Mapping()
+    {
+        $x509 = new X509();
+
+        // These ASN1 constructs are copied from X509.
+        $AlgorithmIdentifier = array(
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => array(
+                'algorithm'  => array('type' => ASN1::TYPE_OBJECT_IDENTIFIER),
+                'parameters' => array(
+                    'type' => ASN1::TYPE_ANY,
+                    'optional' => true,
+                ),
+            ),
+        );
+
+        $CertificateSerialNumber = array('type' => ASN1::TYPE_INTEGER);
+        // End of copied ASN1 constructs.
+
+        $revokedInfo = array(
+            'revocationTime' => array('type' => ASN1::TYPE_GENERALIZED_TIME),
+            'revocationReason' => $x509->CRLReason + array(
+                'constant' => 0,
+                'explicit' => true,
+                'optional' => true,
+            ),
+        );
+
+        $certStatus = array(
+            'type' => ASN1::TYPE_CHOICE,
+            'children' => array(
+                'good' => array(
+                    'type' => ASN1::TYPE_NULL,
+                    'constant' => 0,
+                    'implicit' => true,
+                ),
+                'revoked' => array(
+                    'type' => ASN1::TYPE_SEQUENCE,
+                    'constant' => 1,
+                    'implicit' => true,
+                    'children' => array(
+                        'revocationTime' => array('type' => ASN1::TYPE_GENERALIZED_TIME),
+                        'revocationReason'
+                    ),
+                ),
+                'unknown' => '',
+            ),
+        );
+
+        $version = array(
+            'type' => ASN1::TYPE_INTEGER,
+            'mapping' => array(0 => 'v1'),
+        );
+
+        $responderId = array(
+            'type' => ASN1::TYPE_CHOICE,
+            'children' => array(
+                // Added 'explicit' => true - otherwise the parser breaks.
+                'byName' => $x509->Name + array('constant' => 1, 'explicit' => true),
+                'byKey' => array(
+                    'constant' => 2,
+                    'type' => ASN1::TYPE_OCTET_STRING, // SHA-1 hash of responder's public key
+                ),
+            ),
+        );
+
+        $certId = array(
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => array(
+                'hashAlgorithm' => $AlgorithmIdentifier,
+                'issuerNameHash' => array('type' => ASN1::TYPE_OCTET_STRING), // Hash of Issuer's DN
+                'issuerKeyHash' => array('type' => ASN1::TYPE_OCTET_STRING), // Hash of Issuer's public key
+                'serialNumber' => $CertificateSerialNumber,
+            )
+        );
+
+        $singleResponse = array(
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => array(
+                'certID' => $certId,
+                'certStatus' => $certStatus,
+                'thisUpdate' => array('type' => ASN1::TYPE_GENERALIZED_TIME),
+            ),
+        );
+
+        $revokedInfo = array(
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => array(
+                'revocationTime' => array('type' => ASN1::TYPE_GENERALIZED_TIME),
+                'revocationReason' => $x509->CRLReason + array(
+                    'constant' => 0,
+                    'explicit' => true,
+                    'optional' => true,
+                ),
+            ),
+        );
+
+        $certStatus = array(
+            'type' => ASN1::TYPE_CHOICE,
+            'children' => array(
+                'good' => array(
+                    'type' => ASN1::TYPE_NULL,
+                    'constant' => 0,
+                    'implicit' => true,
+                ),
+                'revoked' => $revokedInfo + array(
+                    'constant' => 1,
+                    'implicit' => true,
+                ),
+                'unknown' => array(
+                    'constant' => 2,
+                    'implicit' => true,
+                    'type' => ASN1::TYPE_NULL,
+                ),
+            ),
+        );
+
+        $tbsResponseData = array(
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => array(
+                'version' => $version + array(
+                    'explicit' => true,
+                    'constant' => 0,
+                    'default' => 'v1'
+                ),
+                'responderID' => $responderId,
+                'producedAt' => array('type' => ASN1::TYPE_GENERALIZED_TIME),
+                'responses' => array('type' => ASN1::TYPE_SEQUENCE, 'min' => 0, 'max' => -1, 'children' => $singleResponse),
+                'responseExtensions' => $x509->Extensions + array(
+                    'explicit' => true,
+                    'constant' => 1,
+                    'optional' => true,
+                ),
+            ),
+        );
+
+        $basicOcspResponse = array(
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => array(
+                'tbsResponseData' => $tbsResponseData,
+                'signatureAlgorithm' => $AlgorithmIdentifier,
+                'signature' => array('type' => ASN1::TYPE_BIT_STRING),
+                'certs' => array(
+                    'constant' => 0,
+                    'explicit' => true,
+                    'optional' => true,
+                    'min' => 0,
+                    'max' => -1,
+                    'children' => $x509->Certificate,
+                ),
+            ),
+        );
+
+        return $basicOcspResponse;
     }
 }

--- a/src/X509/Asn1.php
+++ b/src/X509/Asn1.php
@@ -22,62 +22,42 @@ use phpseclib\File\X509 as BaseAsn1;
 class Asn1
 {
     /**
-     * AlgorithmIdentifier  ::=  SEQUENCE  {
-     *      algorithm               OBJECT IDENTIFIER,
-     *      parameters              ANY DEFINED BY algorithm OPTIONAL  }
-     *                                 -- contains a value of the type
-     *                                 -- registered for use with the
-     *                                 -- algorithm object identifier value
+     * @see https://tools.ietf.org/html/rfc5280#section-4.1.1.2
      *
      * @var array
      */
     public $AlgorithmIdentifier;
 
     /**
-     * Certificate  ::=  SEQUENCE  {
-     *      tbsCertificate       TBSCertificate,
-     *      signatureAlgorithm   AlgorithmIdentifier,
-     *      signatureValue       BIT STRING  }
+     * @see https://tools.ietf.org/html/rfc5280#section-4.1
      *
      * @var array
      */
     public $Certificate;
 
     /**
-     * CertificateSerialNumber  ::=  INTEGER
+     * @see https://tools.ietf.org/html/rfc5280#section-4.1
      *
      * @var array
      */
     public $CertificateSerialNumber;
 
     /**
-     * CRLReason ::= ENUMERATED {
-     *      unspecified             (0),
-     *      keyCompromise           (1),
-     *      cACompromise            (2),
-     *      affiliationChanged      (3),
-     *      superseded              (4),
-     *      cessationOfOperation    (5),
-     *      certificateHold         (6),
-     *           -- value 7 is not used
-     *      removeFromCRL           (8),
-     *      privilegeWithdrawn      (9),
-     *      aACompromise           (10) }
+     * @see https://tools.ietf.org/html/rfc5280#section-5.3.1
      *
      * @var array
      */
     public $CRLReason;
 
     /**
-     * Extensions  ::=  SEQUENCE SIZE (1..MAX) OF Extension
+     * @see https://tools.ietf.org/html/rfc5280#section-4.1
      *
      * @var array
      */
     public $Extensions;
 
     /**
-     * Name ::= CHOICE { -- only one possibility for now --
-     *       rdnSequence  RDNSequence
+     * @see https://tools.ietf.org/html/rfc5280#section-4.1.2.4
      *
      * @var array
      */

--- a/src/X509/Asn1.php
+++ b/src/X509/Asn1.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc\X509;
+
+use phpseclib\File\X509 as BaseAsn1;
+
+/**
+ * A subset of X509 ASN.1 used by this library. Casing of properties matches
+ * the spec.
+ *
+ * @see https://tools.ietf.org/html/rfc5280#appendix-A
+ */
+class Asn1
+{
+    /**
+     * AlgorithmIdentifier  ::=  SEQUENCE  {
+     *      algorithm               OBJECT IDENTIFIER,
+     *      parameters              ANY DEFINED BY algorithm OPTIONAL  }
+     *                                 -- contains a value of the type
+     *                                 -- registered for use with the
+     *                                 -- algorithm object identifier value
+     *
+     * @var array
+     */
+    public $AlgorithmIdentifier;
+
+    /**
+     * Certificate  ::=  SEQUENCE  {
+     *      tbsCertificate       TBSCertificate,
+     *      signatureAlgorithm   AlgorithmIdentifier,
+     *      signatureValue       BIT STRING  }
+     *
+     * @var array
+     */
+    public $Certificate;
+
+    /**
+     * CertificateSerialNumber  ::=  INTEGER
+     *
+     * @var array
+     */
+    public $CertificateSerialNumber;
+
+    /**
+     * CRLReason ::= ENUMERATED {
+     *      unspecified             (0),
+     *      keyCompromise           (1),
+     *      cACompromise            (2),
+     *      affiliationChanged      (3),
+     *      superseded              (4),
+     *      cessationOfOperation    (5),
+     *      certificateHold         (6),
+     *           -- value 7 is not used
+     *      removeFromCRL           (8),
+     *      privilegeWithdrawn      (9),
+     *      aACompromise           (10) }
+     *
+     * @var array
+     */
+    public $CRLReason;
+
+    /**
+     * Extensions  ::=  SEQUENCE SIZE (1..MAX) OF Extension
+     *
+     * @var array
+     */
+    public $Extensions;
+
+    /**
+     * Name ::= CHOICE { -- only one possibility for now --
+     *       rdnSequence  RDNSequence
+     *
+     * @var array
+     */
+    public $Name;
+
+    public function __construct()
+    {
+        $baseAsn1 = new BaseAsn1();
+
+        $TBSCertificate = $baseAsn1->Certificate['children']['tbsCertificate'];
+        $this->AlgorithmIdentifier = $TBSCertificate['children']['signature'];
+        $this->Certificate = $baseAsn1->Certificate;
+        $this->CertificateSerialNumber = $TBSCertificate['children']['serialNumber'];
+        $this->CRLReason = $baseAsn1->CRLReason;
+        $this->Extensions = $baseAsn1->Extensions;
+        $this->Name = $baseAsn1->Name;
+    }
+}

--- a/tests/Ocsp/RequestTest.php
+++ b/tests/Ocsp/RequestTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc\Tests\Ocsp;
+
+use KG\DigiDoc\Ocsp\Request;
+use org\bovigo\vfs\vfsStream;
+
+class RequestTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException KG\DigiDoc\Exception\FileNotFoundException
+     */
+    public function testConstructFailsIfClientCertNotFound()
+    {
+        vfsStream::setUp('root', null, array(
+            $nameOfIssuerCert = 'issuerCert.pem' => '',
+        ));
+
+        $pathToClientCert = vfsStream::url('root/clientCert.pem');
+        $pathToIssuerCert = vfsStream::url('root/' . $nameOfIssuerCert);
+
+        $this->assertFileNotExists($pathToClientCert);
+        $this->assertFileExists($pathToIssuerCert);
+
+        $request = new Request($pathToClientCert, $pathToIssuerCert);
+    }
+
+    /**
+     * @expectedException KG\DigiDoc\Exception\FileNotFoundException
+     */
+    public function testConstructFailsIfIssuerCertNotFound()
+    {
+        vfsStream::setUp('root', null, array(
+            $nameOfClientCert = 'clientCert.pem' => '',
+        ));
+
+        $pathToClientCert = vfsStream::url('root/' . $nameOfClientCert);
+        $pathToIssuerCert = vfsStream::url('root/issuerCert.pem');
+
+        $this->assertFileExists($pathToClientCert);
+        $this->assertFileNotExists($pathToIssuerCert);
+
+        $request = new Request($pathToClientCert, $pathToIssuerCert);
+    }
+
+    public function testGetPathToClientCert()
+    {
+        vfsStream::setUp('root', null, array(
+            $nameOfClientCert = 'clientCert.pem' => '',
+            $nameOfIssuerCert = 'issuerCert.pem' => '',
+        ));
+
+        $pathToClientCert = vfsStream::url('root/' . $nameOfClientCert);
+        $pathToIssuerCert = vfsStream::url('root/' . $nameOfIssuerCert);
+
+        $request = new Request($pathToClientCert, $pathToIssuerCert);
+        $this->assertEquals($pathToClientCert, $request->getPathToClientCert());
+    }
+
+    public function testGetPathToIssuerCert()
+    {
+        vfsStream::setUp('root', null, array(
+            $nameOfClientCert = 'clientCert.pem' => '',
+            $nameOfIssuerCert = 'issuerCert.pem' => '',
+        ));
+
+        $pathToClientCert = vfsStream::url('root/' . $nameOfClientCert);
+        $pathToIssuerCert = vfsStream::url('root/' . $nameOfIssuerCert);
+
+        $request = new Request($pathToClientCert, $pathToIssuerCert);
+        $this->assertEquals($pathToIssuerCert, $request->getPathToIssuerCert());
+    }
+}

--- a/tests/Ocsp/ResponderTest.php
+++ b/tests/Ocsp/ResponderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KG\DigiDoc\Tests\Ocsp;
+
+use KG\DigiDoc\Ocsp\Responder;
+use org\bovigo\vfs\vfsStream;
+
+class ResponderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException KG\DigiDoc\Exception\FileNotFoundException
+     */
+    public function testConstructFailsIfFileNotFound()
+    {
+        $responder = new Responder('http://example.com', 'does/not/exist');
+    }
+
+    public function testHandleGeneratesCorrectCommandLine()
+    {
+        $root = vfsStream::setUp();
+        $pathToResponderCert = vfsStream::newFile('issuerCert.pem')->at($root)->url();
+
+        $expectedCommandLine = sprintf(
+            "?openssl ocsp -issuer '%s' -cert '%s' -url '%s' -VAfile '%s' -respout '.*'?",
+            $pathToIssuerCert = 'path/to/issuer.pem',
+            $pathToClientCert = 'path/to/client.pem',
+            $url = 'http://example.com',
+            $pathToResponderCert
+        );
+
+        $process = $this->getMockProcess();
+        $process->method('isSuccessful')->willReturn(true);
+        $process
+            ->expects($this->once())
+            ->method('setCommandLine')
+            ->with($this->matchesRegularExpression($expectedCommandLine))
+        ;
+
+
+        $request = $this->getMockRequest();
+        $request->method('getPathToClientCert')->willReturn($pathToClientCert);
+        $request->method('getPathToIssuerCert')->willReturn($pathToIssuerCert);
+
+        $responder = new Responder($url, $pathToResponderCert, vfsStream::url('root'), $process);
+        $responder->handle($request);
+    }
+
+    /**
+     * @expectedException KG\DigiDoc\Exception\OcspRequestException
+     */
+    public function testHandleFailsIfProcesssUnsuccessful()
+    {
+        $pathToResponderCert = vfsStream::newFile('issuerCert.pem')
+            ->at(vfsStream::setUp())
+            ->url()
+        ;
+
+        $process = $this->getMockProcess();
+        $process->method('isSuccessful')->willReturn(false);
+
+        $responder = new Responder('http://example.com', $pathToResponderCert, null, $process);
+        $responder->handle($this->getMockRequest());
+    }
+
+    public function testHandleReturnsResponseIfSuccessful()
+    {
+        $pathToResponderCert = vfsStream::newFile('issuerCert.pem')
+            ->at(vfsStream::setUp())
+            ->url()
+        ;
+
+        $process = $this->getMockProcess();
+        $process->method('isSuccessful')->willReturn(true);
+
+        $responder = new Responder('http://example.com', $pathToResponderCert, null, $process);
+        $response = $responder->handle($this->getMockRequest());
+
+        $this->assertInstanceOf('KG\DigiDoc\OCSP\Response', $response);
+    }
+
+    private function getMockProcess()
+    {
+        return $this
+            ->getMockBuilder('Symfony\Component\Process\Process')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    private function getMockRequest()
+    {
+        return $this
+            ->getMockBuilder('KG\DigiDoc\Ocsp\Request')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+}

--- a/tests/Ocsp/ResponseTest.php
+++ b/tests/Ocsp/ResponseTest.php
@@ -11,6 +11,7 @@ namespace KG\Tests\DigiDoc\Ocsp;
  * file that was distributed with this source code.
  */
 
+use KG\DigiDoc\Ocsp\Asn1;
 use KG\DigiDoc\Ocsp\Response;
 
 class ResponseTest extends \PHPUnit_Framework_TestCase
@@ -31,7 +32,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $response = new Response($this->getResponseBer());
 
-        $this->assertSame(RESPONSE::OCSP_SUCCESSFUL, $response->getStatus());
+        $this->assertSame(Asn1::OCSP_SUCCESSFUL, $response->getStatus());
     }
 
     /**

--- a/tests/Ocsp/ResponseTest.php
+++ b/tests/Ocsp/ResponseTest.php
@@ -26,4 +26,38 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response = new Response('foo');
         $this->assertEquals('foo', (string) $response);
     }
+
+    public function testGetStatusReturnsInteger()
+    {
+        $response = new Response($this->getResponseBer());
+
+        $this->assertSame(RESPONSE::OCSP_SUCCESSFUL, $response->getStatus());
+    }
+
+    /**
+     * @group foo
+     */
+    public function testNonceCorrect()
+    {
+        $response = new Response($this->getResponseBer());
+
+        $this->assertTrue($response->isNonceEqualTo(pack("H*" , '0410c3204485aa9860df89c81b858fb09cd8')));
+    }
+
+    private function getResponseBer()
+    {
+        return base64_decode(
+            'MIICVwoBAKCCAlAwggJMBgkrBgEFBQcwAQEEggI9MIICOTCCASGhgYYwgYMxCzAJBgNVBAYTAkVF' .
+            'MSIwIAYDVQQKDBlBUyBTZXJ0aWZpdHNlZXJpbWlza2Vza3VzMQ0wCwYDVQQLDARPQ1NQMScwJQYD' .
+            'VQQDDB5URVNUIG9mIFNLIE9DU1AgUkVTUE9OREVSIDIwMTExGDAWBgkqhkiG9w0BCQEWCXBraUBz' .
+            'ay5lZRgPMjAxNDEyMjAxMzQ0MDhaMGAwXjBJMAkGBSsOAwIaBQAEFJ8hzI+QiAAqq1ikY3MvViFZ' .
+            'KzWuBBR7avJVUFy42XoIh0Gu+qIrPVtXdgIQH/v/rqwJX11SX33gZ4PrfYAAGA8yMDE0MTIyMDEz' .
+            'NDQwOFqhIzAhMB8GCSsGAQUFBzABAgQSBBDDIESFqphg34nIG4WPsJzYMA0GCSqGSIb3DQEBBQUA' .
+            'A4IBAQAPE20l+8tr4pZv1Mm6Fsad7ZP7tVlNb+jl0KxWrD3InL+Q38tzrlo8XHn2AMkkscqclPgZ' .
+            'KQSm3Gz4ZtI61sV7nPBI5UTlCpCcstlDaMoL2FjEn4mwIt2pJg1lYdMH0Lg5pZZzjZw5F51PWv9C' .
+            'zSqhlPtXSYWretux8ZlWdwqX4VUvm4jBT18J0c9hjhWr85FJhFo2QcMAsX5lEuYLdjlbb5+3fCw1' .
+            '/0FZ1h8xFp6Yiu4Bp3il5Um1YSnUXHxLtA4ScZ+vMI9n0aFmQJBdxrq/7Kd3GsPcOcWlgiSaqTgA' .
+            'V9uaoOe/hQSF1O/MC8dpTzhClAfaPCiU6lVa2yUn8JIV'
+        );
+    }
 }

--- a/tests/Ocsp/ResponseTest.php
+++ b/tests/Ocsp/ResponseTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace KG\Tests\DigiDoc\Ocsp;
+
+/*
+ * This file is part of the DigiDoc package.
+ *
+ * (c) Kristen Gilden <kristen.gilden@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use KG\DigiDoc\Ocsp\Response;
+
+class ResponseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetContent()
+    {
+        $response = new Response('foo');
+        $this->assertEquals('foo', $response->getContent());
+    }
+
+    public function testResponseImplementsToString()
+    {
+        $response = new Response('foo');
+        $this->assertEquals('foo', (string) $response);
+    }
+}


### PR DESCRIPTION
Preparations to start moving towards getting rid of DigiDocService.

[DigiDoc's file format standard](https://www.sk.ee/repository/bdoc-spec21.pdf) has a few gotchas regarding OCSP. It requires sending hashes of signatures as part of an OCSP request as [nonces](http://www.alvestrand.no/objectid/1.3.6.1.5.5.7.48.1.2.html).

Parsing responses using ASN.1 removes the need to do any hacky parsing of openSSL's CLI output.

A few things should be done before this can be merged:
- [x] move ASN.1 declarations to separate classes (ideally `Asn1\Ocsp` and `Asn1\X509`, the latter would mostly wrap `phpseclib`'s `X509` class);
- [ ] ~~consider completely skipping openSSL for making requests as there's no way to set custom nonces (probably separate PR)~~ won't do at this point;
- [ ] ~~improve error checking in `Response` now that we can do all sorts of fancy stuff with the response~~ (#5);
