### PR TITLE
Api::setClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-zip": "*",
         "doctrine/collections": "~1.0",
         "symfony/process": "~2.0",
-        "phpseclib/phpseclib": "dev-php5"
+        "phpseclib/phpseclib": "*"
     },
     "require-dev": {
         "wsdl2phpgenerator/wsdl2phpgenerator": "~2.3",

--- a/src/Api.php
+++ b/src/Api.php
@@ -284,4 +284,12 @@ class Api implements ApiInterface
             throw ApiException::createNotMerged($envelope);
         }
     }
+
+    /**
+     * @param \SoapClient $client
+     */
+    public function setClient(\SoapClient $client)
+    {
+        $this->client = $client;
+    }
 }

--- a/src/ApiInterface.php
+++ b/src/ApiInterface.php
@@ -108,4 +108,14 @@ interface ApiInterface
      * @param Envelope $envelope
      */
     public function merge(Envelope $envelope);
+
+    /**
+     * Sets the Client.
+     * Api can not be stored in a session without SoapClient failing. So in
+     * order for storing the Api along with other objects in session, we
+     * need to replace the client after retrieving the objects.
+     *
+     * @param \SoapClient $client
+     */
+    public function setClient(\SoapClient $client);
 }


### PR DESCRIPTION
I'm using this package in an AngularJS project, where I can't get the certificate and sign a document with one request. And as SoapClient doesn't support being stored in a Session I'm going to replace it after retrieving everything from the Session.
